### PR TITLE
feat: Enhance Frontend UI/UX

### DIFF
--- a/godot-frontend/assets/modern_theme.tres
+++ b/godot-frontend/assets/modern_theme.tres
@@ -1,0 +1,64 @@
+[gd_resource type="Theme" load_steps=7 format=3 uid="uid://c2vj7q0x0x7vx"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_progressbar_fg"]
+bg_color = Color(0.2, 0.7, 0.3, 1) # Vibrant Green
+corner_radius_top_left = 3
+corner_radius_top_right = 3
+corner_radius_bottom_right = 3
+corner_radius_bottom_left = 3
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_progressbar_bg"]
+bg_color = Color(0.1, 0.1, 0.15, 1) # Darker Grey/Blue
+corner_radius_top_left = 3
+corner_radius_top_right = 3
+corner_radius_bottom_right = 3
+corner_radius_bottom_left = 3
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_button_normal"]
+bg_color = Color(0.2, 0.3, 0.5, 1)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.4, 0.5, 0.7, 1)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_button_hover"]
+bg_color = Color(0.3, 0.4, 0.6, 1)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.5, 0.6, 0.8, 1)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_button_pressed"]
+bg_color = Color(0.15, 0.25, 0.45, 1)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.3, 0.4, 0.6, 1)
+corner_radius_top_left = 5
+corner_radius_top_right = 5
+corner_radius_bottom_right = 5
+corner_radius_bottom_left = 5
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panel"]
+bg_color = Color(0.1, 0.1, 0.2, 1)
+
+[resource]
+default_font_color = Color(0.9, 0.9, 0.9, 1)
+Button/colors/font_color = Color(0.95, 0.95, 0.95, 1)
+Button/styles/hover = SubResource("StyleBoxFlat_button_hover")
+Button/styles/normal = SubResource("StyleBoxFlat_button_normal")
+Button/styles/pressed = SubResource("StyleBoxFlat_button_pressed")
+Panel/styles/panel = SubResource("StyleBoxFlat_panel")
+TextureProgressBar/styles/background = SubResource("StyleBoxFlat_progressbar_bg")
+TextureProgressBar/styles/fill = SubResource("StyleBoxFlat_progressbar_fg")

--- a/godot-frontend/scenes/HowToPlay.tscn
+++ b/godot-frontend/scenes/HowToPlay.tscn
@@ -1,0 +1,63 @@
+[gd_scene load_steps=2 format=3 uid="uid://dglqk5y2k5cnv"]
+
+[ext_resource type="Theme" uid="uid://c2vj7q0x0x7vx" path="res://assets/modern_theme.tres" id="1_theme"]
+
+[node name="HowToPlayScreen" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_theme")
+
+[node name="Panel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="VBoxContainer" type="VBoxContainer" parent="Panel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 20.0
+offset_top = 20.0
+offset_right = -20.0
+offset_bottom = -20.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 15
+
+[node name="TitleLabel" type="Label" parent="Panel/VBoxContainer"]
+layout_mode = 2
+theme_override_font_sizes/font_size = 48 # Assuming theme has base font size, this overrides
+text = "How to Play"
+horizontal_alignment = 1 # Center
+
+[node name="InstructionsLabel" type="RichTextLabel" parent="Panel/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3 # Expand Fill
+bbcode_enabled = true
+text = "[ul]
+[li]Objective: Guess the phrase based on the emojis shown.[/li]
+[li]Gameplay: Select one of the four options that you think matches the emojis.[/li]
+[li]Timer: You have 15 seconds for each round.[/li]
+[li]Scoring: Earn points for each correct answer.[/li]
+[li]Hints: If you're stuck, use the 'Hint' button (details TBD).[/li]
+[/ul]"
+fit_content = true
+scroll_active = false # If content might overflow, set true
+
+[node name="Spacer" type="Control" parent="Panel/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3 # Pushes button to bottom if VBox is set to expand children
+
+[node name="BackButton" type="Button" parent="Panel/VBoxContainer"]
+layout_mode = 2
+size_flags_horizontal = 4 # Center
+size_flags_vertical = 8 # Shrink bottom
+text = "Got it!"

--- a/godot-frontend/scenes/Main.tscn
+++ b/godot-frontend/scenes/Main.tscn
@@ -1,6 +1,118 @@
-[gd_scene load_steps=2 format=3 uid="uid://cjh70vu3voqhv"]
+[gd_scene load_steps=8 format=3 uid="uid://cjh70vu3voqhv"]
 
 [ext_resource type="Script" path="res://scripts/main.gd" id="1_main_gd"]
+[ext_resource type="Theme" uid="uid://c2vj7q0x0x7vx" path="res://assets/modern_theme.tres" id="2_theme"]
+
+[sub_resource type="Animation" id="Animation_loading_indicator"]
+resource_name = "loading_indicator_anim"
+length = 0.9
+loop_mode = 1 # Loop
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("../EmojiDisplay:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 0,
+"values": [Color(1, 1, 1, 1)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("../EmojiDisplay:text")
+tracks/1/interp = 1 # Discrete steps
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.3, 0.6),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 1, # Discrete
+"values": ["Loading.", "Loading..", "Loading..."]
+}
+
+[sub_resource type="Animation" id="Animation_change_emoji"]
+resource_name = "change_emoji_content"
+length = 0.25
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("../EmojiDisplay:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.25),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 1), Color(1, 1, 1, 0)]
+}
+tracks/1/type = "method"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("../..")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0.25),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"_on_emoji_fade_out_complete"
+}]
+}
+
+[sub_resource type="Animation" id="Animation_hint_popup"]
+resource_name = "hint_popup_appear"
+length = 0.3
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("../../HintPopup:scale")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.3),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(0.8, 0.8), Vector2(1, 1)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("../../HintPopup:modulate")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 0.3),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="Animation" id="Animation_emoji_fade_in"]
+resource_name = "emoji_fade_in"
+length = 0.5
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("../EmojiDisplay:modulate")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.5),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Color(1, 1, 1, 0), Color(1, 1, 1, 1)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_main"]
+_data = {
+"change_emoji_content": SubResource("Animation_change_emoji"),
+"emoji_fade_in": SubResource("Animation_emoji_fade_in"),
+"hint_popup_appear": SubResource("Animation_hint_popup"),
+"loading_indicator_anim": SubResource("Animation_loading_indicator")
+}
 
 [node name="Main" type="Control"]
 layout_mode = 3
@@ -10,6 +122,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_main_gd")
+theme = ExtResource("2_theme")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1
@@ -26,12 +139,27 @@ theme_override_constants/separation = 15
 
 [node name="TopBar" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
-alignment = 1 # Center alignment for the content of TopBar itself if needed
+# Consider changing alignment to BEGIN or END if buttons on one side are preferred
+# alignment = 1 # Center alignment for the content of TopBar itself if needed
+
+[node name="HowToPlayButton" type="Button" parent="VBoxContainer/TopBar"]
+layout_mode = 2
+size_flags_horizontal = 2 # Shrink Center, or 0 for Shrink Begin
+text = "How to Play"
 
 [node name="TimerLabel" type="Label" parent="VBoxContainer/TopBar"]
 layout_mode = 2
-size_flags_horizontal = 3 # Expand Fill
+size_flags_horizontal = 1 # Fill, but allow shrink
 text = "Time: 15"
+
+[node name="VisualTimer" type="TextureProgressBar" parent="VBoxContainer/TopBar"]
+layout_mode = 2
+size_flags_horizontal = 3 # Expand Fill
+size_flags_vertical = 1 # Center align vertically if TopBar has extra height
+min_value = 0.0
+max_value = 15.0
+value = 15.0
+fill_mode = 4 # FILL_RIGHT_TO_LEFT
 
 [node name="ScoreLabel" type="Label" parent="VBoxContainer/TopBar"]
 layout_mode = 2
@@ -40,12 +168,18 @@ text = "Score: 0"
 horizontal_alignment = 2 # Right align text within Label
 
 [node name="EmojiDisplay" type="Label" parent="VBoxContainer"]
+modulate = Color(1, 1, 1, 0)
 layout_mode = 2
 size_flags_vertical = 3 # Expand Fill
 theme_override_font_sizes/font_size = 72
 text = "😃❓"
 horizontal_alignment = 1 # Center
 vertical_alignment = 1 # Center
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="VBoxContainer"]
+libraries = {
+"": SubResource("AnimationLibrary_main")
+}
 
 [node name="Options" type="HBoxContainer" parent="VBoxContainer"]
 layout_mode = 2
@@ -92,6 +226,7 @@ grow_vertical = 0   # Don't grow with parent
 text = "Hint"
 
 [node name="HintPopup" type="PopupPanel" parent="."]
+modulate = Color(1, 1, 1, 0)
 title = "Hint" # Set a title for the popup window
 initial_position = 2 # Center of parent (Main node)
 size = Vector2i(300, 150) # Use Vector2i for size property of PopupPanel

--- a/godot-frontend/scripts/main.gd
+++ b/godot-frontend/scripts/main.gd
@@ -1,19 +1,33 @@
 extends Control
 
-@onready var emoji_display = $EmojiDisplay
-@onready var option_buttons = [$Options/Option1, $Options/Option2, $Options/Option3, $Options/Option4]
-@onready var score_label = $TopBar/ScoreLabel
-@onready var timer_label = $TopBar/TimerLabel
-@onready var hint_button = $HintButton
-@onready var hint_popup = $HintPopup
-@onready var hint_text = $HintPopup/HintText
+@onready var emoji_display = $VBoxContainer/EmojiDisplay
+@onready var option_buttons = [
+    $VBoxContainer/Options/Option1,
+    $VBoxContainer/Options/Option2,
+    $VBoxContainer/Options/Option3,
+    $VBoxContainer/Options/Option4
+]
+@onready var score_label = $VBoxContainer/TopBar/ScoreLabel
+@onready var timer_label = $VBoxContainer/TopBar/TimerLabel
+@onready var hint_button = $VBoxContainer/HintButton
+@onready var hint_popup = $HintPopup # This is a direct child of Main
+@onready var hint_text = $HintPopup/HintText # This is correct relative to HintPopup
+@onready var animation_player = $VBoxContainer/AnimationPlayer
+@onready var visual_timer = $VBoxContainer/TopBar/VisualTimer
+@onready var how_to_play_button = $VBoxContainer/TopBar/HowToPlayButton
 @onready var http_request = HTTPRequest.new()
+
+const HowToPlayScene = preload("res://scenes/HowToPlay.tscn")
+var how_to_play_instance = null
+var game_was_active_before_tutorial = false # To handle timer resume correctly
 
 var backend_url = "http://localhost:3000"
 var current_phrase = "" # This will store the correct answer string
 var score = 0
 var timer_sec = 15.0 # Use float for delta accumulation
 var timer_active = false
+var _next_emoji_text = "" # For change_emoji_content animation
+var _original_hint_button_text = "" # For hint button loading text
 
 func _ready():
     add_child(http_request)
@@ -22,7 +36,61 @@ func _ready():
         btn.connect("pressed", Callable(self, "_on_option_pressed").bind(btn))
     # Connect the main request_completed signal here for combo responses initially
     http_request.connect("request_completed", Callable(self, "_on_combo_request_completed"))
+
+    how_to_play_button.connect("pressed", Callable(self, "_on_how_to_play_pressed"))
+
+    # Instantiate and prepare HowToPlay screen
+    if HowToPlayScene:
+        how_to_play_instance = HowToPlayScene.instantiate()
+        add_child(how_to_play_instance)
+        how_to_play_instance.visible = false
+        var back_button = how_to_play_instance.get_node_or_null("Panel/VBoxContainer/BackButton")
+        if back_button:
+            back_button.connect("pressed", Callable(self, "_on_how_to_play_closed"))
+        else:
+            print("Error: Back button not found in HowToPlay scene instance at path: Panel/VBoxContainer/BackButton")
+
+    visual_timer.max_value = timer_sec # Initialize max_value, could also be done in editor
+    visual_timer.value = timer_sec      # Initialize current value
     start_new_round()
+
+func _on_how_to_play_pressed():
+    if how_to_play_instance:
+        how_to_play_instance.visible = true
+        game_was_active_before_tutorial = timer_active
+        timer_active = false # Pause timer
+        # Disable game buttons
+        for btn in option_buttons:
+            btn.disabled = true
+        hint_button.disabled = true
+
+func _on_how_to_play_closed():
+    if how_to_play_instance:
+        how_to_play_instance.visible = false
+        if game_was_active_before_tutorial: # Only resume if it was active
+             # Check if a round is actually in progress (not loading/error)
+            if emoji_display.text != "Loading..." and emoji_display.text != "Error loading combo!" and emoji_display.text != "Options Error!" and emoji_display.text != "Data Error!":
+                timer_active = true
+        game_was_active_before_tutorial = false # Reset flag
+
+        # Re-enable game buttons only if a round is active and not showing an error
+        var round_is_interactive = emoji_display.text != "Loading..." and \
+                                   emoji_display.text != "Error loading combo!" and \
+                                   emoji_display.text != "Options Error!" and \
+                                   emoji_display.text != "Data Error!" and \
+                                   timer_sec > 0
+
+        if round_is_interactive:
+            for btn in option_buttons:
+                # Check if the option text itself indicates it's a real option vs placeholder/error
+                if btn.text != "" and not btn.text.begins_with("Option "): # Basic check
+                    btn.disabled = false
+            hint_button.disabled = false
+        else: # If round is not interactive (e.g. loading, error, or between rounds)
+            for btn in option_buttons:
+                btn.disabled = true
+            hint_button.disabled = true
+
 
 func start_new_round():
     reset_timer()
@@ -30,22 +98,31 @@ func start_new_round():
         btn.disabled = true # Disable buttons until options are loaded
         btn.release_focus() # Remove focus from any previously pressed button
         btn.remove_theme_color_override("font_color") # Ensure colors are reset
-    emoji_display.text = "Loading..."
+
+    emoji_display.modulate.a = 1 # Ensure it's visible for loading animation
+    animation_player.play("loading_indicator_anim")
     hint_button.disabled = true # Disable hint button until phrase is loaded
     # Make sure this request is specifically for combos
     http_request.request(backend_url + "/combo") # Removed "?category=general" as backend doesn't use it
 
+func _on_emoji_fade_out_complete():
+    emoji_display.text = _next_emoji_text
+    animation_player.play("emoji_fade_in")
+
 func reset_timer():
     timer_sec = 15.0
     timer_label.text = "Time: 15"
+    visual_timer.value = timer_sec # Reset visual timer
     timer_active = false
 
 func _process(delta):
     if timer_active:
         timer_sec -= delta
         timer_label.text = "Time: " + str(int(max(0,timer_sec))) # Ensure time doesn't go negative
+        visual_timer.value = timer_sec # Update visual timer
         if timer_sec <= 0:
             timer_active = false
+            visual_timer.value = 0 # Ensure it's visually empty
             show_correct_answer_feedback(false) # Pass false as it's a timeout
             await get_tree().create_timer(1.5).timeout
             start_new_round()
@@ -53,6 +130,10 @@ func _process(delta):
 func _on_hint_button_pressed():
     if current_phrase == "" or not timer_active: # Also check if timer is active
         return
+
+    _original_hint_button_text = hint_button.text
+    hint_button.text = "Fetching..."
+    hint_button.disabled = true # Ensure it's disabled
 
     # Disconnect combo handler if connected, to prevent it from processing hint response
     if http_request.is_connected("request_completed", Callable(self, "_on_combo_request_completed")):
@@ -65,17 +146,20 @@ func _on_hint_button_pressed():
     var json_body = JSON.stringify(body)
     var headers = ["Content-Type: application/json"]
     http_request.request(backend_url + "/hint", headers, HTTPClient.METHOD_POST, json_body)
-    hint_button.disabled = true # Disable hint button after use for this round
+    # hint_button.disabled = true # Already disabled above
 
 
 # Specific handler for combo request responses
 func _on_combo_request_completed(result, response_code, headers, body):
+    animation_player.stop() # Stop loading_indicator_anim
+
     if response_code != 200:
         print("HTTP error for combo request: ", response_code)
         emoji_display.text = "Error loading combo!"
+        emoji_display.modulate.a = 1 # Make it visible directly
         # Optionally, try to load another combo or show an error to the user
         await get_tree().create_timer(2.0).timeout # Brief pause before retrying
-        start_new_round()
+        start_new_round() # This will trigger loading animation again
         return
 
     var response_string = body.get_string_from_utf8()
@@ -83,10 +167,8 @@ func _on_combo_request_completed(result, response_code, headers, body):
 
     if response and response.has("emojis") and response.has("options") and response.has("correct_answer"):
         current_phrase = response["correct_answer"] # Store the correct answer string
-        # Assuming response["emojis"] is a string like "🧑‍🍳💋" from the backend.
-        # If it's an array of single emojis, " ".join() would be good.
-        # If it's already a two-emoji string, direct assignment is fine.
-        emoji_display.text = response["emojis"] 
+        _next_emoji_text = response["emojis"]
+        animation_player.play("change_emoji_content") # This will fade out "Loading...", then call method to set new text & fade in
         
         if response["options"].size() == option_buttons.size():
             # Shuffle options client-side for better randomness if desired, or ensure backend shuffles well
@@ -98,8 +180,9 @@ func _on_combo_request_completed(result, response_code, headers, body):
         else:
             print("Error: Number of options from backend (", response["options"].size(), ") does not match number of buttons (", option_buttons.size(), ").")
             emoji_display.text = "Options Error!"
+            emoji_display.modulate.a = 1 # Make error visible
             await get_tree().create_timer(2.0).timeout
-            start_new_round()
+            start_new_round() # This will trigger loading animation again
             return
 
         timer_active = true # Start timer only after UI is updated
@@ -108,31 +191,39 @@ func _on_combo_request_completed(result, response_code, headers, body):
     else:
         print("Invalid combo data structure from backend: ", response_string)
         emoji_display.text = "Data Error!"
+        emoji_display.modulate.a = 1 # Make error visible
         await get_tree().create_timer(2.0).timeout
-        start_new_round()
+        start_new_round() # This will trigger loading animation again
 
 # Specific handler for hint request responses
 func _on_hint_request_completed(result, response_code, headers, body):
+    hint_button.text = _original_hint_button_text # Restore original text
+
     if response_code == 200:
         var response_string = body.get_string_from_utf8()
         var response = JSON.parse_string(response_string)
         if response and response.has("hint"):
             hint_text.text = response["hint"]
-            hint_popup.popup_centered()
         else:
             print("Invalid hint data structure from backend: ", response_string)
             hint_text.text = "Hint error." # Show some error in popup
-            hint_popup.popup_centered()
     else:
         print("Hint request failed: ", response_code)
         hint_text.text = "Could not fetch hint."
-        hint_popup.popup_centered()
+
+    hint_popup.modulate.a = 0.0
+    hint_popup.scale = Vector2(0.8, 0.8)
+    hint_popup.popup_centered() # Position it first
+    animation_player.play("hint_popup_appear") # Then play animation
     
     # Reconnect the combo handler for subsequent combo requests
     # This is crucial because the hint handler used CONNECT_ONE_SHOT or was manually disconnected.
     if not http_request.is_connected("request_completed", Callable(self, "_on_combo_request_completed")):
         http_request.connect("request_completed", Callable(self, "_on_combo_request_completed"))
-    hint_button.disabled = false # Re-enable in case of error, or manage as per game rules
+
+    # Re-enable hint button only if timer is still active (i.e., player didn't lose/win while hint was fetching)
+    if timer_active:
+        hint_button.disabled = false
 
 
 func show_correct_answer_feedback(is_correct_choice):


### PR DESCRIPTION
I've implemented a comprehensive set of UI/UX improvements for the Godot frontend:

1.  **Visual Appeal**:
    *   Introduced a new Godot Theme (`modern_theme.tres`) for consistent styling, including improved font color, background, and button appearances.
    *   Added fade-in/out animations for the main emoji display during content loading and transitions.
    *   Implemented an animation for the hint popup, making it scale and fade in.

2.  **Interactive Feedback**:
    *   Refined button styles in the theme to provide clear visual feedback for hover and pressed states.
    *   Added a `TextureProgressBar` as a visual timer, synchronized with the text-based timer, to provide a more engaging countdown.

3.  **"How to Play" Screen**:
    *   Created a new scene (`HowToPlay.tscn`) with game instructions.
    *   Added a "How to Play" button to the main game screen to access this tutorial.
    *   Implemented logic to show/hide the tutorial screen, including pausing the game timer and disabling main game interactions while the tutorial is active.

4.  **Loading Indicators**:
    *   Replaced the static "Loading..." text with an animated text sequence ("Loading.", "Loading..", "Loading...") on the main emoji display during backend requests.
    *   Changed the hint button's text to "Fetching..." during hint requests to provide clearer feedback.

These changes significantly improve the game's aesthetics, user feedback, and provide necessary guidance for new players.